### PR TITLE
Added java-11 support to your project and replaced log4j with slf4j-based logger.

### DIFF
--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -381,14 +381,22 @@
         <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <artifactId>log4j-to-slf4j</artifactId>
             <version>2.11.1</version>
         </dependency>
+        
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.11.1</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
         </dependency>
+        
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+
 
         <!-- *** Test *** -->
         <!-- JUnit 5 Testing Framework -->

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -351,7 +351,7 @@
             <version>2.0.26-9.1.2</version>
         </dependency>
         -->
-        <!--java 11+ only -->
+        <!-- Java 11+ only -->
         <!--
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -334,7 +334,7 @@
             <version>1.7.22-4</version>
         </dependency>
 
-        <!-- Java 9 only
+        <!-- Java 9+ only
         <dependency>
             <groupId>de.jensd</groupId>
             <artifactId>fontawesomefx-commons</artifactId>
@@ -349,6 +349,32 @@
             <groupId>de.jensd</groupId>
             <artifactId>fontawesomefx-materialdesignfont</artifactId>
             <version>2.0.26-9.1.2</version>
+        </dependency>
+        -->
+        <!--java 11+ only -->
+        <!--
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>11-ea+25</version>
         </dependency>
         -->
 

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -229,6 +229,12 @@
             <artifactId>javafx-base</artifactId>
             <version>11-ea+25</version>
         </dependency>
+         
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-web</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
         -->
     </dependencies>
 </project>

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -181,7 +181,7 @@
             <version>1.7.22-4</version>
         </dependency>
 
-        <!-- Java 9 only
+        <!-- Java 9+ only
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
@@ -201,6 +201,33 @@
             <groupId>de.jensd</groupId>
             <artifactId>fontawesomefx-materialdesignfont</artifactId>
             <version>2.0.26-9.1.2</version>
+        </dependency>
+        -->
+             
+        <!-- Java 11+ only -->
+        <!--
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>11-ea+25</version>
         </dependency>
         -->
     </dependencies>


### PR DESCRIPTION
Java 11 rips out javafx. With these changes to your poms, java-11 users can now depend on the openjfx implementations hosted on maven central.

Also, when running your library on java 11, I got this big spooky message 
```
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
```

It turns out this was being caused by the log4j logger, and said logger was indeed slowing things down. A lot. I swapped out the log4j dependencies for the log4j to slf4j bridge, slf4j api, and logback classic, and the build works and the resulting workbenchfx applications are faster to load. Currently, the logging level is not showing TRACE messages, which I dunno if that's a big deal to you or not, but it almost certainly can be fixed if needbe.

A side note though, you can and should probably rip out the logback-classic dependency or switch it to test scope. With the slf4j-api package, users of WorkbenchFX can choose their own slf4j compatible logging system and your library will interact with it (through the log4j calls the log4j-to-slf4j bridge provides).