### PR TITLE
Make it possible to execute demo with Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ File                | Description
 `CustomDemo.java`   | A workbench application which uses all features, to demonstrate the full capability of *WorkbenchFX*
 `FXMLDemo.java`     | A minimal example of how to use *WorkbenchFX* with FXML & [Scene Builder](https://gluonhq.com/products/scene-builder/)
 
+**Important:** To run the demos, execute the maven task 
+```XML
+mvn exec:java
+```
+
 # Getting started
 ## Extending the WorkbenchModule
 It is required to create a new class and extend `WorkbenchModule`, in order to create a custom module:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Note:
 We created several demos to visualize the capabilities of *WorkbenchFX* in the `workbenchfx-demo` folder.
 To run the demos, execute the corresponding maven goal according to the table below with the working directory set as `workbenchfx-demo`:
 
+**Important:** Please run `mvn clean install` at least once before executing one of the maven goals in the table below, or else you might run into a `ClassNotFoundException`.
+
 File                | Description                                                                                                            | Maven Goal
 ------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------
 `SimpleDemo.java`   | Shows the simplest usage of *WorkbenchFX* with only three modules and no optional features used                        | `mvn exec:java@simple-demo`

--- a/README.md
+++ b/README.md
@@ -183,19 +183,15 @@ Note:
 - The full documentation about the module lifecycle can be found in the documentation file `workbenchfx-demo/src/main/resources/com/dlsc/workbenchfx/modules/webview/index.html`, in the section *WorkbenchModule Lifecycle*
 
 # Demos
-We created several demos to visualize the capabilities of *WorkbenchFX* in the `workbenchfx-demo` folder:
+We created several demos to visualize the capabilities of *WorkbenchFX* in the `workbenchfx-demo` folder.
+To run the demos, execute the corresponding maven goal according to the table below with the working directory set as `workbenchfx-demo`:
 
-File                | Description
-------------------- | -----------
-`SimpleDemo.java`   | Shows the simplest usage of *WorkbenchFX* with only three modules and no optional features used
-`ExtendedDemo.java` | Shows a simple workbench application with most of the features used in a simple way.
-`CustomDemo.java`   | A workbench application which uses all features, to demonstrate the full capability of *WorkbenchFX*
-`FXMLDemo.java`     | A minimal example of how to use *WorkbenchFX* with FXML & [Scene Builder](https://gluonhq.com/products/scene-builder/)
-
-**Important:** To run the demos, execute the maven task 
-```XML
-mvn exec:java
-```
+File                | Description                                                                                                            | Maven Goal
+------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------
+`SimpleDemo.java`   | Shows the simplest usage of *WorkbenchFX* with only three modules and no optional features used                        | `mvn exec:java@simple-demo`
+`ExtendedDemo.java` | Shows a simple workbench application with most of the features used in a simple way.                                   | `mvn exec:java@extended-demo`
+`CustomDemo.java`   | A workbench application which uses all features, to demonstrate the full capability of *WorkbenchFX*                   | `mvn exec:java@custom-demo`
+`FXMLDemo.java`     | A minimal example of how to use *WorkbenchFX* with FXML & [Scene Builder](https://gluonhq.com/products/scene-builder/) | `mvn exec:java@fxml-demo`
 
 # Getting started
 ## Extending the WorkbenchModule

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -76,9 +76,8 @@
 
         <!-- JUnit -->
         <junit.version>4.12</junit.version>
-        <junit.jupiter.version>5.2.0</junit.jupiter.version>
-        <junit.vintage.version>5.2.0</junit.vintage.version>
-        <junit.platform.version>1.2.0</junit.platform.version>
+        <junit.jupiter.version>5.3.2</junit.jupiter.version>
+        <junit.vintage.version>5.3.2</junit.vintage.version>
     </properties>
 
     <build>
@@ -401,7 +400,7 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.1-groovy-2.4</version>
+            <version>1.2-groovy-2.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -423,21 +422,21 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-core</artifactId>
-            <version>4.0.13-alpha</version>
+            <version>4.0.15-alpha</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
-            <version>4.0.13-alpha</version>
+            <version>4.0.15-alpha</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-spock</artifactId>
-            <version>4.0.13-alpha</version>
+            <version>4.0.15-alpha</version>
             <scope>test</scope>
         </dependency>
 

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -181,7 +181,7 @@
             </plugin>
 
             <!-- Checkstyle -->
-            <!--plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.0.0</version>
@@ -210,7 +210,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin-->
+            </plugin>
 
             <!-- Generates CodeCoverage Report -->
             <plugin>
@@ -234,9 +234,9 @@
             </plugin>
 
             <!-- Execute Tests (JUnit / Spock) -->
-            <!--plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.1</version>
                 <configuration>
                     <excludedGroups>slow</excludedGroups>
                     <includes>
@@ -244,7 +244,7 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
-            </plugin-->
+            </plugin>
 
             <!-- Groovy Compiler for Spock Tests -->
             <plugin>

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -76,8 +76,9 @@
 
         <!-- JUnit -->
         <junit.version>4.12</junit.version>
-        <junit.jupiter.version>5.3.2</junit.jupiter.version>
-        <junit.vintage.version>5.3.2</junit.vintage.version>
+        <junit.jupiter.version>5.2.0</junit.jupiter.version>
+        <junit.vintage.version>5.2.0</junit.vintage.version>
+        <junit.platform.version>1.2.0</junit.platform.version>
     </properties>
 
     <build>
@@ -200,6 +201,7 @@
                     <includeTestSourceDirectory>false</includeTestSourceDirectory>
                     <failOnViolation>true</failOnViolation>
                     <violationSeverity>warning</violationSeverity>
+                    <excludes>**/module-info.java</excludes>
                 </configuration>
                 <executions>
                     <execution>
@@ -234,9 +236,9 @@
             </plugin>
 
             <!-- Execute Tests (JUnit / Spock) -->
-            <plugin>
+            <!--plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>2.22.0</version>
                 <configuration>
                     <excludedGroups>slow</excludedGroups>
                     <includes>
@@ -244,13 +246,13 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
-            </plugin>
+            </plugin-->
 
             <!-- Groovy Compiler for Spock Tests -->
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6.2</version>
+                <version>1.6.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -285,7 +287,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -324,7 +326,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
+            <version>26.0-jre</version>
         </dependency>
 
         <dependency>
@@ -351,13 +353,13 @@
             <artifactId>log4j-to-slf4j</artifactId>
             <version>2.11.1</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
         </dependency>
-        
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -400,21 +402,21 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.2-groovy-2.5</version>
+            <version>1.1-groovy-2.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.9.5</version>
+            <version>1.8.16</version>
             <scope>test</scope>
         </dependency>
 
         <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
-            <version>3.0.1</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
 
@@ -422,21 +424,21 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-core</artifactId>
-            <version>4.0.15-alpha</version>
+            <version>4.0.13-alpha</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
-            <version>4.0.15-alpha</version>
+            <version>4.0.13-alpha</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-spock</artifactId>
-            <version>4.0.15-alpha</version>
+            <version>4.0.13-alpha</version>
             <scope>test</scope>
         </dependency>
 
@@ -444,21 +446,21 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
+            <version>2.21.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.11.1</version>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.1.5</version>
+            <version>3.1.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -306,19 +306,20 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>11-ea+25</version>
+            <version>11.0.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
-            <version>11-ea+25</version>
+            <version>11.0.1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>11-ea+25</version>
+            <version>11.0.1</version>
         </dependency>
 
         <dependency>

--- a/workbenchfx-core/pom.xml
+++ b/workbenchfx-core/pom.xml
@@ -250,7 +250,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6.1</version>
+                <version>1.6.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -285,7 +285,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -324,7 +324,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
+            <version>27.0.1-jre</version>
         </dependency>
 
         <dependency>
@@ -407,14 +407,14 @@
         <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.8.16</version>
+            <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
 
         <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
-            <version>2.6</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -444,21 +444,21 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.21.0</version>
+            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.10.0</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/workbenchfx-core/src/main/java/module-info.java
+++ b/workbenchfx-core/src/main/java/module-info.java
@@ -1,6 +1,5 @@
 module com.dlsc.workbenchfx.core {
     requires javafx.controls;
-    requires javafx.swing;
     requires org.apache.logging.log4j;
     requires com.google.common;
     requires de.jensd.fx.glyphs.fontawesome;

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -258,38 +258,5 @@
             <type>pom</type>
         </dependency>
 
-             
-        <!-- Java 11+ only -->
-        <!--
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
-            <version>11-ea+25</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-fxml</artifactId>
-            <version>11-ea+25</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-graphics</artifactId>
-            <version>11-ea+25</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-base</artifactId>
-            <version>11-ea+25</version>
-        </dependency>
-         
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-web</artifactId>
-            <version>11-ea+25</version>
-        </dependency>
-        -->
     </dependencies>
 </project>

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-web</artifactId>
-            <version>11-ea+25</version>
+            <version>11.0.1</version>
         </dependency>
 
         <dependency>

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -116,6 +116,22 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>com.dlsc.workbenchfx.demo.CustomDemo</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -180,6 +180,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.lynden</groupId>
             <artifactId>GMapsFX</artifactId>
             <version>2.12.0</version>

--- a/workbenchfx-demo/pom.xml
+++ b/workbenchfx-demo/pom.xml
@@ -123,14 +123,45 @@
                 <version>1.6.0</version>
                 <executions>
                     <execution>
+                        <id>custom-demo</id>
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>com.dlsc.workbenchfx.demo.CustomDemo</mainClass>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>extended-demo</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>com.dlsc.workbenchfx.demo.ExtendedDemo</mainClass>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>fxml-demo</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>com.dlsc.workbenchfx.demo.FXMLDemo</mainClass>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>simple-demo</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>com.dlsc.workbenchfx.demo.SimpleDemo</mainClass>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <mainClass>com.dlsc.workbenchfx.demo.CustomDemo</mainClass>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Under some circumstances, it was not possible to run the demos with Java 11. Now by executing the `mvn exec:java` goal, it should be possible in every way.